### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new
@@ -19,14 +19,15 @@ class ItemsController < ApplicationController
     @item = Item.new(item_params)
     if @item.save
       redirect_to root_path
-   else
-     render :new
-   end
- end
+    else
+      render :new
+    end
+  end
 
   private
 
   def item_params
-    params.permit(:image, :name, :description, :price, :category_id, :condition_id, :days_to_ship_id, :delivery_area_id, :shipping_id).merge(user_id: current_user.id)
+    params.permit(:image, :name, :description, :price, :category_id, :condition_id, :days_to_ship_id, :delivery_area_id,
+                  :shipping_id).merge(user_id: current_user.id)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -15,5 +15,4 @@ class Category < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -11,5 +11,4 @@ class Condition < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-  
-  end
+end

--- a/app/models/days_to_ship.rb
+++ b/app/models/days_to_ship.rb
@@ -8,6 +8,4 @@ class DaysToShip < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-  
-  end
-  
+end

--- a/app/models/delivery_area.rb
+++ b/app/models/delivery_area.rb
@@ -1,25 +1,24 @@
 class DeliveryArea < ActiveHash::Base
   self.data = [
-      {id: 1, name: '--' },
-      {id: 2, name: '北海道'}, {id: 3, name: '青森県'}, {id: 4, name: '岩手県'},
-      {id: 5, name: '宮城県'}, {id: 6, name: '秋田県'}, {id: 7, name: '山形県'},
-      {id: 8, name: '福島県'}, {id: 9, name: '茨城県'}, {id: 10, name: '栃木県'},
-      {id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'}, {id: 13, name: '千葉県'},
-      {id: 14, name: '東京都'}, {id: 15, name: '神奈川県'}, {id: 16, name: '新潟県'},
-      {id: 17, name: '富山県'}, {id: 18, name: '石川県'}, {id: 19, name: '福井県'},
-      {id: 20, name: '山梨県'}, {id: 21, name: '長野県'}, {id: 22, name: '岐阜県'},
-      {id: 23, name: '静岡県'}, {id: 24, name: '愛知県'}, {id: 25, name: '三重県'},
-      {id: 26, name: '滋賀県'}, {id: 27, name: '京都府'}, {id: 28, name: '大阪府'},
-      {id: 29, name: '兵庫県'}, {id: 30, name: '奈良県'}, {id: 31, name: '和歌山県'},
-      {id: 32, name: '鳥取県'}, {id: 33, name: '島根県'}, {id: 34, name: '岡山県'},
-      {id: 35, name: '広島県'}, {id: 36, name: '山口県'}, {id: 37, name: '徳島県'},
-      {id: 38, name: '香川県'}, {id: 39, name: '愛媛県'}, {id: 40, name: '高知県'},
-      {id: 41, name: '福岡県'}, {id: 42, name: '佐賀県'}, {id: 43, name: '長崎県'},
-      {id: 44, name: '熊本県'}, {id: 45, name: '大分県'}, {id: 46, name: '宮崎県'},
-      {id: 47, name: '鹿児島県'}, {id: 48, name: '沖縄県'}
+    { id: 1, name: '--' },
+    { id: 2, name: '北海道' }, { id: 3, name: '青森県' }, { id: 4, name: '岩手県' },
+    { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' }, { id: 7, name: '山形県' },
+    { id: 8, name: '福島県' }, { id: 9, name: '茨城県' }, { id: 10, name: '栃木県' },
+    { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' }, { id: 13, name: '千葉県' },
+    { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' }, { id: 16, name: '新潟県' },
+    { id: 17, name: '富山県' }, { id: 18, name: '石川県' }, { id: 19, name: '福井県' },
+    { id: 20, name: '山梨県' }, { id: 21, name: '長野県' }, { id: 22, name: '岐阜県' },
+    { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' }, { id: 25, name: '三重県' },
+    { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' }, { id: 28, name: '大阪府' },
+    { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' }, { id: 31, name: '和歌山県' },
+    { id: 32, name: '鳥取県' }, { id: 33, name: '島根県' }, { id: 34, name: '岡山県' },
+    { id: 35, name: '広島県' }, { id: 36, name: '山口県' }, { id: 37, name: '徳島県' },
+    { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' }, { id: 40, name: '高知県' },
+    { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' }, { id: 43, name: '長崎県' },
+    { id: 44, name: '熊本県' }, { id: 45, name: '大分県' }, { id: 46, name: '宮崎県' },
+    { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-  
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,13 +10,12 @@ class Item < ApplicationRecord
   has_one_attached :image
 
   with_options presence: true do
+    validates :name, :description, :price, :image
 
-  validates :name, :description, :price, :image
+    validates :price,
+              format: { with: /\A[0-9]+\z/ }, numericality: { only_integer: true,
+                                                              greater_than: 300, less_than: 10_000_000 }
 
-  validates :price,
-  format: { with: /\A[0-9]+\z/ }, numericality: { only_integer: true,
-  greater_than: 300, less_than: 10000000 } 
-
-  validates :category_id, :condition_id, :days_to_ship_id, :delivery_area_id, :shipping_id, numericality: { other_than: 1 } 
+    validates :category_id, :condition_id, :days_to_ship_id, :delivery_area_id, :shipping_id, numericality: { other_than: 1 }
   end
 end

--- a/app/models/shipping.rb
+++ b/app/models/shipping.rb
@@ -7,5 +7,4 @@ class Shipping < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-  
-  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,20 +5,18 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   with_options presence: true do
-
-  VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
-  validates :password, length: { minimum: 6, maximum: 32 }, format: { with: VALID_PASSWORD_REGEX }  
-  validates :nickname
-  validates :last_name,
-            format: { with: /\A([ぁ-んァ-ン一-龥]|ー)+\z/ }
-  validates :first_name,
-            format: { with: /\A([ぁ-んァ-ン一-龥]|ー)+\z/ }
-  validates :last_name_kana,
-            format: { with: /\A([ァ-ン]|ー)+\z/ }
-  validates :first_name_kana,
-            format: { with: /\A([ァ-ン]|ー)+\z/ }
-  validates :birthday
-
+    VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
+    validates :password, length: { minimum: 6, maximum: 32 }, format: { with: VALID_PASSWORD_REGEX }
+    validates :nickname
+    validates :last_name,
+              format: { with: /\A([ぁ-んァ-ン一-龥]|ー)+\z/ }
+    validates :first_name,
+              format: { with: /\A([ぁ-んァ-ン一-龥]|ー)+\z/ }
+    validates :last_name_kana,
+              format: { with: /\A([ァ-ン]|ー)+\z/ }
+    validates :first_name_kana,
+              format: { with: /\A([ァ-ン]|ー)+\z/ }
+    validates :birthday
   end
 
   has_many :items

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :category do
-    
   end
 end

--- a/spec/factories/conditions.rb
+++ b/spec/factories/conditions.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :condition do
-    
   end
 end

--- a/spec/factories/days_to_ships.rb
+++ b/spec/factories/days_to_ships.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :days_to_ship do
-    
   end
 end

--- a/spec/factories/delivery_areas.rb
+++ b/spec/factories/delivery_areas.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :delivery_area do
-    
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,13 +2,12 @@ FactoryBot.define do
   factory :item do
     name                  { 'テスト' }
     description           { 'テスト説明' }
-    condition_id          {2}
-    shipping_id           {2}
-    category_id           {2}
-    delivery_area_id      {2}
-    days_to_ship_id       {2}
-    price                 {10000}
+    condition_id          { 2 }
+    shipping_id           { 2 }
+    category_id           { 2 }
+    delivery_area_id      { 2 }
+    days_to_ship_id       { 2 }
+    price                 { 10_000 }
     user
-
   end
 end

--- a/spec/factories/shippings.rb
+++ b/spec/factories/shippings.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :shipping do
-    
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 describe Item do
   before do
     @item = FactoryBot.build(:item)
-    @item.image = fixture_file_upload("/files/boowy.png")
+    @item.image = fixture_file_upload('/files/boowy.png')
   end
 
   describe '商品出品' do
@@ -26,27 +26,27 @@ describe Item do
       it 'condition_idが1では登録できない' do
         @item.condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Condition must be other than 1")
+        expect(@item.errors.full_messages).to include('Condition must be other than 1')
       end
       it 'category_idが1では登録できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
       it 'shipping_idが1では登録できない' do
         @item.shipping_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping must be other than 1")
+        expect(@item.errors.full_messages).to include('Shipping must be other than 1')
       end
       it 'category_idが1では登録できない' do
         @item.delivery_area_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery area must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery area must be other than 1')
       end
       it 'days_to_ship_idが1では登録できない' do
         @item.days_to_ship_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Days to ship must be other than 1")
+        expect(@item.errors.full_messages).to include('Days to ship must be other than 1')
       end
       it 'priceが空では登録できない' do
         @item.price = nil
@@ -56,22 +56,22 @@ describe Item do
       it 'priceが300円未満では登録できない' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than 300")
+        expect(@item.errors.full_messages).to include('Price must be greater than 300')
       end
       it 'priceが¥10000000円以上では登録できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than 10000000")
+        expect(@item.errors.full_messages).to include('Price must be less than 10000000')
       end
       it 'priceは半角数字でしか登録できない(全角)' do
         @item.price = '１１１１'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it 'priceは半角数字でしか登録できない(半角英字)' do
         @item.price = 'five hundred'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it 'imageが空では登録できない' do
         @item.image = nil

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -99,73 +99,73 @@ describe User do
       it 'last_nameが全角漢字・ひらがな・カタカナ以外では登録できない(半角英字)' do
         @user.last_name = 'test'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name is invalid")
+        expect(@user.errors.full_messages).to include('Last name is invalid')
       end
       it 'last_nameが全角漢字・ひらがな・カタカナ以外では登録できない(記号)' do
         @user.last_name = '%%%%'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name is invalid")
+        expect(@user.errors.full_messages).to include('Last name is invalid')
       end
       it 'first_nameが全角漢字・ひらがな・カタカナ以外では登録できない(半角英字)' do
         @user.first_name = 'test'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name is invalid")
+        expect(@user.errors.full_messages).to include('First name is invalid')
       end
       it 'first_nameが全角漢字・ひらがな・カタカナ以外では登録できない(記号)' do
         @user.first_name = '%%%%'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name is invalid")
+        expect(@user.errors.full_messages).to include('First name is invalid')
       end
       it 'last_name_kanaが全角カタカナ以外では登録できない(全角)' do
         @user.last_name_kana = '全角'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana is invalid")
+        expect(@user.errors.full_messages).to include('Last name kana is invalid')
       end
       it 'last_name_kanaが全角カタカナ以外では登録できない(かな)' do
         @user.last_name_kana = 'かな'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana is invalid")
+        expect(@user.errors.full_messages).to include('Last name kana is invalid')
       end
       it 'last_name_kanaが全角カタカナ以外では登録できない(半角英字)' do
         @user.last_name_kana = 'test'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana is invalid")
+        expect(@user.errors.full_messages).to include('Last name kana is invalid')
       end
       it 'last_name_kanaが全角カタカナ以外では登録できない(数字)' do
         @user.last_name_kana = '1234'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana is invalid")
+        expect(@user.errors.full_messages).to include('Last name kana is invalid')
       end
       it 'last_name_kanaが全角カタカナ以外では登録できない(記号)' do
         @user.last_name_kana = '%%%%'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana is invalid")
+        expect(@user.errors.full_messages).to include('Last name kana is invalid')
       end
 
       it 'first_name_kanaが全角カタカナ以外では登録できない(全角)' do
         @user.first_name_kana = '全角'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana is invalid")
+        expect(@user.errors.full_messages).to include('First name kana is invalid')
       end
       it 'first_name_kanaが全角カタカナ以外では登録できない(かな)' do
         @user.first_name_kana = 'かな'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana is invalid")
+        expect(@user.errors.full_messages).to include('First name kana is invalid')
       end
       it 'first_name_kanaが全角カタカナ以外では登録できない(半角英字)' do
         @user.first_name_kana = 'test'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana is invalid")
+        expect(@user.errors.full_messages).to include('First name kana is invalid')
       end
       it 'first_name_kanaが全角カタカナ以外では登録できない(数字)' do
         @user.first_name_kana = '1234'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana is invalid")
+        expect(@user.errors.full_messages).to include('First name kana is invalid')
       end
       it 'first_name_kanaが全角カタカナ以外では登録できない(記号)' do
         @user.first_name_kana = '%%%%'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana is invalid")
+        expect(@user.errors.full_messages).to include('First name kana is invalid')
       end
     end
   end


### PR DESCRIPTION
# What
商品情報編集機能実装(ただしSoldOut関連は除く)

# Why
ユーザーが出品した商品の情報を変更できるようにするため。

Gyazo GIFリンク
何も編集せずに更新をしても画像無しの商品にならないこと
https://gyazo.com/b81a56461476fb5c82c0fc0e1043fd9d

ログイン状態の出品者以外のユーザーは、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
https://gyazo.com/345478e98731387b28ac8ba47e92709c

エラーハンドリング
https://gyazo.com/4332d30644548b603bb7b59543cbb0f5